### PR TITLE
Drop --ensure-latest from brakeman binstub

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
`--ensure-latest` makes `bin/brakeman` exit non-zero when the pinned brakeman isn't the newest release, so `scan_ruby` failed on the newer open PRs (exit 5, no findings) once brakeman 8.0.5 shipped while the lockfile pinned 8.0.4. Dependabot already bumps brakeman, so this gate only caused flaky red CI. Removing it makes scan_ruby reflect actual scan results.